### PR TITLE
Add React and Angular example integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,230 @@
-# AIProjects
+# Voice Assist Plugin
+
+A framework-agnostic voice and AI assistant that can be plugged into any web application. The plugin listens for focus events on text inputs, textareas, and `contenteditable` elements, then displays an overlay with:
+
+- **Speech-to-text** capture using the browser's Web Speech API.
+- **AI-powered text transformations** such as fixing grammar, summarising, or expanding content.
+- **On-page AI configuration** so that end users can switch models, endpoints, or keys without redeploying your app.
+
+The library is written in plain JavaScript and exports a single class that you can import from any Node.js-based bundler (Webpack, Vite, Next.js, Create React App, Angular CLI, etc.) or reference directly in vanilla JS via an ES module `<script>` tag.
+
+## Installation
+
+Add the package to your project (adjust the path to where you place the plugin source):
+
+```bash
+npm install ./path/to/voice-assist-plugin
+# or
+pnpm add ./path/to/voice-assist-plugin
+```
+
+You can also copy the `src` directory into your project if you prefer to bundle it directly.
+
+## Quick start
+
+```js
+import VoiceAssistPlugin from 'voice-assist-plugin';
+
+const assist = new VoiceAssistPlugin({
+  aiConfig: {
+    endpoint: 'https://api.openai.com/v1/chat/completions',
+    apiKey: process.env.MY_AI_KEY,
+    model: 'gpt-3.5-turbo'
+  },
+  speechConfig: {
+    locale: 'en-US',
+    insertionMode: 'append' // append | replace-selection | replace-all
+  }
+});
+```
+
+Once instantiated, the assistant attaches itself to all focusable text inputs within the current document. Click inside any text box and the overlay appears.
+
+> **TypeScript**: The package ships with type declarations so you get IntelliSense and compile-time safety out of the box.
+
+### Vanilla JavaScript example
+
+A ready-to-run example is located at [`examples/basic.html`](examples/basic.html). Open it via a local web server (for example `npx serve examples`) and provide your AI endpoint/key through the configuration panel.
+
+### React demo application
+
+A complete Vite starter that wires the plugin into a React component lives in [`examples/react-app`](examples/react-app/). Install
+the dependencies and start the dev server:
+
+```bash
+cd examples/react-app
+npm install
+npm run dev
+```
+
+Then visit [http://localhost:5173](http://localhost:5173) and focus the textarea to summon the assistant overlay.
+
+### Angular demo application
+
+An Angular CLI standalone project showcasing the same integration is available at
+[`examples/angular-app`](examples/angular-app/):
+
+```bash
+cd examples/angular-app
+npm install
+npm start
+```
+
+Open [http://localhost:4200](http://localhost:4200) in your browser and click into the textarea. Use the gear icon inside the
+overlay to enter your API key or to switch models at runtime.
+
+### React usage
+
+```jsx
+import { useEffect } from 'react';
+import VoiceAssistPlugin from 'voice-assist-plugin';
+
+export function EditorPage() {
+  useEffect(() => {
+    const plugin = new VoiceAssistPlugin({
+      aiConfig: {
+        endpoint: process.env.REACT_APP_AI_ENDPOINT,
+        apiKey: process.env.REACT_APP_AI_KEY,
+        model: 'gpt-4o'
+      }
+    });
+
+    return () => plugin.destroy();
+  }, []);
+
+  return <textarea placeholder="Start typing…" />;
+}
+```
+
+### Angular usage
+
+```ts
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import VoiceAssistPlugin from 'voice-assist-plugin';
+import { environment } from '../environments/environment';
+
+@Component({
+  selector: 'app-editor',
+  template: `<textarea placeholder="Start typing…"></textarea>`
+})
+export class EditorComponent implements OnInit, OnDestroy {
+  private plugin?: VoiceAssistPlugin;
+
+  ngOnInit() {
+    this.plugin = new VoiceAssistPlugin({
+      aiConfig: {
+        endpoint: environment.aiEndpoint,
+        apiKey: environment.aiKey,
+        model: 'gpt-3.5-turbo'
+      }
+    });
+  }
+
+  ngOnDestroy() {
+    this.plugin?.destroy();
+  }
+}
+```
+
+## Configuration
+
+### AI configuration (`aiConfig`)
+
+| Option | Type | Description |
+| ------ | ---- | ----------- |
+| `endpoint` | `string` | **Required**. The HTTP endpoint for your LLM/chat completion provider. |
+| `apiKey` | `string` | Optional API key. If omitted, you can fill it through the in-page configuration panel. |
+| `model` | `string` | Model name sent to the default OpenAI-style payload builder. |
+| `headers` | `Record<string, string>` | Extra headers to send with every request. |
+| `systemPrompt` | `string` | Optional system prompt used by the default payload builder. |
+| `buildPayload` | `(ctx) => object` | Custom function to build the request body. Receives `{ instruction, text, config, prompt }`. |
+| `transformResponse` | `(data) => string` | Custom function to extract the assistant text from the response object. |
+
+Call `plugin.setAIConfig(nextConfig)` at any time to update the settings programmatically. The UI also exposes a configuration panel (gear icon) that writes to the same store, making dynamic model switching trivial.
+
+You can completely replace the network call by supplying your own `aiRequest` function:
+
+```js
+const plugin = new VoiceAssistPlugin({
+  aiRequest: async ({ text, instruction, prompt, config }) => {
+    const response = await fetch('/api/rewrite', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, instruction, promptId: prompt.id })
+    });
+    const data = await response.json();
+    return data.output;
+  }
+});
+```
+
+If you want to reuse the built-in OpenAI-compatible request helper, import `defaultAiRequest`:
+
+```js
+import VoiceAssistPlugin, { defaultAiRequest } from 'voice-assist-plugin';
+
+const plugin = new VoiceAssistPlugin({
+  aiRequest: (ctx) => defaultAiRequest({ ...ctx, config: {
+    ...ctx.config,
+    endpoint: 'https://my-proxy.example.com/v1/chat/completions'
+  } })
+});
+```
+
+### Speech recognition (`speechConfig`)
+
+| Option | Type | Description |
+| ------ | ---- | ----------- |
+| `locale` | `string` | Locale passed to `SpeechRecognition.lang` (default `en-US`). |
+| `interimResults` | `boolean` | Whether interim results should be captured. |
+| `insertionMode` | `'append' \| 'replace-selection' \| 'replace-all'` | How speech and AI results are inserted. |
+
+Speech capture uses the [Web Speech API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Speech_API). If the API is not available, the plugin displays an inline warning and disables the button.
+
+Call `plugin.setSpeechConfig({ insertionMode: 'replace-all' })` at runtime to change how speech results are inserted, or inspect the current settings with `plugin.getSpeechConfig()`.
+
+### Prompts (`prompts`)
+
+Provide an array of objects `{ id, label, instruction }`. Use `plugin.setPrompts([...])` to swap them at runtime. Each prompt becomes a button inside the overlay.
+
+```js
+plugin.setPrompts([
+  { id: 'shorten', label: 'Shorten', instruction: 'Rewrite the text to be shorter.' },
+  { id: 'headline', label: 'Create headline', instruction: 'Write a punchy headline for the following copy.' }
+]);
+```
+
+### Other options
+
+| Option | Type | Description |
+| ------ | ---- | ----------- |
+| `autoAttach` | `boolean` | Set to `false` to instantiate the plugin without registering global focus listeners. Call `plugin.attach()` manually when needed. |
+| `aiInsertionMode` | `'append' \| 'replace-selection' \| 'replace-all'` | Controls how AI responses are placed when no text is selected. Use `plugin.setAiInsertionMode(mode)` to swap it at runtime. |
+
+## Dynamic model switching via UI
+
+End users can click the **⚙️ Config** button to open a form where they can update the endpoint, model, API key, and system prompt. The plugin stores the values in-memory and uses them for subsequent requests without reloading the page.
+
+## Accessing the active element
+
+If you need to trigger actions manually you can use:
+
+```js
+plugin.runAiAction(plugin.prompts[0]);
+plugin.startSpeechCapture();
+```
+
+## Browser support
+
+- Speech-to-text requires Chrome, Edge, or any Chromium-based browser with the Web Speech API enabled.
+- AI requests rely on the Fetch API. Supply a custom `aiRequest` if you target browsers without `fetch`.
+- The overlay is rendered using standard DOM APIs and works alongside React, Angular, Vue, Svelte, or vanilla JavaScript inputs.
+
+## Development
+
+- `npm test` – placeholder command.
+- `examples/basic.html` – open via a static file server to experiment locally.
+
+## License
+
+MIT

--- a/examples/angular-app/README.md
+++ b/examples/angular-app/README.md
@@ -1,0 +1,17 @@
+# Angular demo
+
+This project mirrors a fresh Angular CLI standalone app and wires the voice assistant in `AppComponent`
+after the view initialises. It demonstrates how to manage the plugin lifecycle alongside Angular's
+own component lifecycle hooks.
+
+## Getting started
+
+```bash
+cd examples/angular-app
+npm install
+npm start
+```
+
+Open [http://localhost:4200](http://localhost:4200) and focus the textarea to summon the overlay.
+Provide your API credentials via the assistant's settings panel to start making AI calls without
+modifying the application code.

--- a/examples/angular-app/angular.json
+++ b/examples/angular-app/angular.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "voice-assist-demo": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/voice-assist-demo",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": ["src/polyfills.ts"],
+            "tsConfig": "tsconfig.app.json",
+            "inlineStyleLanguage": "css",
+            "assets": [],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "500kb",
+                  "maximumError": "1mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "2kb",
+                  "maximumError": "4kb"
+                }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "namedChunks": true
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "configurations": {
+            "production": {
+              "browserTarget": "voice-assist-demo:build:production"
+            },
+            "development": {
+              "browserTarget": "voice-assist-demo:build:development"
+            }
+          },
+          "defaultConfiguration": "development"
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "browserTarget": "voice-assist-demo:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "polyfills": ["src/polyfills.ts"],
+            "tsConfig": "tsconfig.app.json",
+            "inlineStyleLanguage": "css",
+            "assets": [],
+            "styles": ["src/styles.css"],
+            "scripts": []
+          }
+        }
+      }
+    }
+  },
+  "defaultProject": "voice-assist-demo"
+}

--- a/examples/angular-app/package.json
+++ b/examples/angular-app/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "voice-assist-angular-example",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test"
+  },
+  "dependencies": {
+    "@angular/animations": "^17.3.0",
+    "@angular/common": "^17.3.0",
+    "@angular/compiler": "^17.3.0",
+    "@angular/core": "^17.3.0",
+    "@angular/forms": "^17.3.0",
+    "@angular/platform-browser": "^17.3.0",
+    "@angular/platform-browser-dynamic": "^17.3.0",
+    "rxjs": "^7.8.1",
+    "tslib": "^2.6.2",
+    "voice-assist-plugin": "file:../..",
+    "zone.js": "^0.14.4"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^17.3.3",
+    "@angular/cli": "^17.3.3",
+    "@angular/compiler-cli": "^17.3.0",
+    "@types/jasmine": "~5.1.0",
+    "jasmine-core": "~5.1.0",
+    "karma": "~6.4.0",
+    "karma-chrome-launcher": "~3.2.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.1.0",
+    "typescript": "~5.3.3"
+  }
+}

--- a/examples/angular-app/src/app/app.component.ts
+++ b/examples/angular-app/src/app/app.component.ts
@@ -1,0 +1,125 @@
+import { AfterViewInit, Component, OnDestroy } from '@angular/core';
+import VoiceAssistPlugin from 'voice-assist-plugin';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  template: `
+    <main class="shell">
+      <section class="intro">
+        <h1>Angular + Voice Assist Plugin</h1>
+        <p>
+          Focus the textarea and the floating assistant will appear next to it. Start a speech capture
+          session or trigger one of the AI prompts, then insert the result right back into the editor.
+          Use the gear icon to configure your endpoint, API key, or switch models at runtime.
+        </p>
+      </section>
+
+      <label class="input-block" for="angular-textarea">
+        <span>Give it a spin</span>
+        <textarea
+          id="angular-textarea"
+          rows="8"
+          placeholder="Place the caret here to summon the assistant overlay."
+        ></textarea>
+      </label>
+
+      <p class="status" [attr.aria-live]="'polite'">
+        {{ ready ? 'Assistant ready — focus a supported text field to try it out.' : 'Initialising assistant…' }}
+      </p>
+    </main>
+  `,
+  styles: [
+    `
+      :host {
+        display: flex;
+        min-height: 100vh;
+        padding: 3rem 1.5rem;
+        justify-content: center;
+        align-items: center;
+      }
+
+      .shell {
+        width: min(720px, 96vw);
+        background: #ffffff;
+        border-radius: 24px;
+        padding: 3rem;
+        box-shadow: 0 40px 90px rgba(15, 23, 42, 0.15);
+        display: flex;
+        flex-direction: column;
+        gap: 1.75rem;
+      }
+
+      .intro h1 {
+        margin: 0 0 0.5rem;
+        font-size: clamp(1.75rem, 4vw, 2.5rem);
+      }
+
+      .intro p {
+        margin: 0;
+        color: #475569;
+        font-size: 1rem;
+        line-height: 1.6;
+      }
+
+      .input-block {
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+        font-size: 0.95rem;
+      }
+
+      .input-block textarea {
+        border-radius: 16px;
+        border: 1px solid #cbd5f5;
+        padding: 1rem 1.25rem;
+        font: inherit;
+        line-height: 1.6;
+        min-height: 200px;
+        resize: vertical;
+        background: #f8fafc;
+      }
+
+      .status {
+        margin: 0;
+        font-size: 0.9rem;
+        color: #64748b;
+      }
+
+      @media (max-width: 640px) {
+        :host {
+          padding: 2rem 1rem;
+        }
+
+        .shell {
+          padding: 2rem 1.5rem;
+        }
+      }
+    `
+  ]
+})
+export class AppComponent implements AfterViewInit, OnDestroy {
+  ready = false;
+  private plugin?: VoiceAssistPlugin;
+
+  ngAfterViewInit(): void {
+    this.plugin = new VoiceAssistPlugin({
+      aiConfig: {
+        endpoint: 'https://api.openai.com/v1/chat/completions',
+        apiKey: '',
+        model: 'gpt-4o-mini'
+      },
+      speechConfig: {
+        locale: 'en-US',
+        insertionMode: 'append'
+      }
+    });
+
+    this.ready = true;
+  }
+
+  ngOnDestroy(): void {
+    this.plugin?.destroy();
+    this.ready = false;
+  }
+}

--- a/examples/angular-app/src/index.html
+++ b/examples/angular-app/src/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Voice Assist Plugin – Angular Demo</title>
+    <base href="/" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/examples/angular-app/src/main.ts
+++ b/examples/angular-app/src/main.ts
@@ -1,0 +1,4 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent).catch((err) => console.error(err));

--- a/examples/angular-app/src/polyfills.ts
+++ b/examples/angular-app/src/polyfills.ts
@@ -1,0 +1,1 @@
+import 'zone.js';

--- a/examples/angular-app/src/styles.css
+++ b/examples/angular-app/src/styles.css
@@ -1,0 +1,15 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: #f1f5f9;
+  color: #0f172a;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/examples/angular-app/tsconfig.app.json
+++ b/examples/angular-app/tsconfig.app.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./dist/out-tsc/app",
+    "types": []
+  },
+  "files": [
+    "src/main.ts",
+    "src/polyfills.ts"
+  ],
+  "include": [
+    "src/**/*.d.ts"
+  ]
+}

--- a/examples/angular-app/tsconfig.base.json
+++ b/examples/angular-app/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "target": "ES2022",
+    "module": "ES2022",
+    "useDefineForClassFields": false,
+    "typeRoots": ["node_modules/@types"],
+    "lib": ["ES2022", "DOM"],
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  }
+}

--- a/examples/angular-app/tsconfig.json
+++ b/examples/angular-app/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Voice Assist Plugin demo</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        margin: 0;
+        padding: 2rem;
+        background: #f8fafc;
+      }
+
+      .demo-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        gap: 2rem;
+      }
+
+      textarea,
+      input,
+      [contenteditable="true"] {
+        width: 100%;
+        min-height: 160px;
+        border-radius: 12px;
+        border: 1px solid #cbd5f5;
+        padding: 1rem;
+        font-size: 0.95rem;
+        line-height: 1.6;
+        box-shadow: 0 10px 40px rgba(15, 23, 42, 0.1);
+        background: white;
+      }
+
+      [contenteditable="true"] {
+        min-height: 220px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Voice Assist Plugin</h1>
+    <p>Click in any text field and try speech-to-text or the AI actions.</p>
+    <div class="demo-grid">
+      <label>
+        Plain textarea
+        <textarea placeholder="Try speaking or use AI actions..."></textarea>
+      </label>
+      <label>
+        Plain input field
+        <input type="text" placeholder="Works with single line inputs as well" />
+      </label>
+      <label>
+        Content editable block
+        <div contenteditable="true">
+          You can also use the assistant with contentEditable editors.
+        </div>
+      </label>
+    </div>
+
+    <script type="module">
+      import VoiceAssistPlugin, { DEFAULT_PROMPTS } from '../src/index.js';
+
+      const plugin = new VoiceAssistPlugin({
+        prompts: DEFAULT_PROMPTS,
+        aiConfig: {
+          endpoint: 'https://api.openai.com/v1/chat/completions',
+          model: 'gpt-3.5-turbo'
+          // Provide apiKey here or via the configuration panel.
+        },
+        speechConfig: {
+          locale: 'en-US',
+          insertionMode: 'append'
+        }
+      });
+
+      window.voiceAssistPlugin = plugin;
+    </script>
+  </body>
+</html>

--- a/examples/react-app/README.md
+++ b/examples/react-app/README.md
@@ -1,0 +1,16 @@
+# React demo
+
+This example bootstraps the plugin inside a minimal Vite + React application. It shows how you can
+instantiate `VoiceAssistPlugin` when the app mounts and clean it up when the component unmounts.
+
+## Getting started
+
+```bash
+cd examples/react-app
+npm install
+npm run dev
+```
+
+Then open the printed URL (defaults to [http://localhost:5173](http://localhost:5173)) and focus the
+textarea. Use the gear icon in the assistant overlay to provide an API key or swap AI models without
+redeploying.

--- a/examples/react-app/index.html
+++ b/examples/react-app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Voice Assist Plugin – React Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/examples/react-app/package.json
+++ b/examples/react-app/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "voice-assist-react-example",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "voice-assist-plugin": "file:../.."
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.4",
+    "vite": "^5.1.0"
+  }
+}

--- a/examples/react-app/src/App.css
+++ b/examples/react-app/src/App.css
@@ -1,0 +1,74 @@
+:root {
+  color-scheme: light;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: #f8fafc;
+  color: #0f172a;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+}
+
+#root {
+  flex: 1;
+  display: flex;
+}
+
+.app-shell {
+  margin: auto;
+  width: min(720px, 90vw);
+  padding: 3rem 2.5rem;
+  background: white;
+  border-radius: 24px;
+  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.hero h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.hero p {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.6;
+  color: #475569;
+}
+
+.input-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.input-block textarea {
+  width: 100%;
+  border-radius: 16px;
+  border: 1px solid #cbd5f5;
+  padding: 1rem 1.25rem;
+  font-family: inherit;
+  font-size: 1rem;
+  line-height: 1.6;
+  resize: vertical;
+  min-height: 200px;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
+.status {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #64748b;
+}
+
+@media (max-width: 600px) {
+  .app-shell {
+    padding: 2rem 1.5rem;
+    border-radius: 16px;
+  }
+}

--- a/examples/react-app/src/App.jsx
+++ b/examples/react-app/src/App.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import VoiceAssistPlugin from 'voice-assist-plugin';
+
+export default function App() {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const plugin = new VoiceAssistPlugin({
+      aiConfig: {
+        endpoint: 'https://api.openai.com/v1/chat/completions',
+        apiKey: '',
+        model: 'gpt-4o-mini'
+      },
+      speechConfig: {
+        locale: 'en-US',
+        insertionMode: 'replace-selection'
+      }
+    });
+
+    setReady(true);
+
+    return () => {
+      plugin.destroy();
+      setReady(false);
+    };
+  }, []);
+
+  return (
+    <main className="app-shell">
+      <section className="hero">
+        <h1>React + Voice Assist Plugin</h1>
+        <p>
+          Focus the textarea below to open the floating assistant. Use the microphone button for
+          speech-to-text and the action chips for quick AI rewrites. Click the gear icon to provide
+          your API key or swap models.
+        </p>
+      </section>
+
+      <label className="input-block" htmlFor="demo-textarea">
+        <span>Try it out</span>
+        <textarea
+          id="demo-textarea"
+          placeholder="Place your cursor here and trigger the assistant."
+          rows={8}
+        />
+      </label>
+
+      <p className="status" role="status">
+        {ready
+          ? 'Assistant ready — focus any supported text input to use it.'
+          : 'Initialising assistant…'}
+      </p>
+    </main>
+  );
+}

--- a/examples/react-app/src/main.jsx
+++ b/examples/react-app/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './App.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/examples/react-app/vite.config.js
+++ b/examples/react-app/vite.config.js
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      'voice-assist-plugin': resolve(__dirname, '../../src/index.js')
+    }
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "voice-assist-plugin",
+  "version": "0.1.0",
+  "description": "Framework-agnostic speech-to-text and AI text assistant plugin for web text inputs.",
+  "type": "module",
+  "main": "src/index.js",
+  "module": "src/index.js",
+  "types": "src/index.d.ts",
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "files": [
+    "src",
+    "examples",
+    "README.md"
+  ],
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [
+    "speech-to-text",
+    "ai",
+    "plugin",
+    "text-assistant",
+    "ui"
+  ],
+  "author": "",
+  "license": "MIT"
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,79 @@
+export type VoiceAssistPrompt = {
+  id: string;
+  label: string;
+  instruction: string;
+};
+
+export type VoiceAssistAiConfig = {
+  provider?: string;
+  endpoint?: string;
+  apiKey?: string;
+  model?: string;
+  headers?: Record<string, string>;
+  systemPrompt?: string;
+  buildPayload?: (ctx: {
+    instruction: string;
+    text: string;
+    config: VoiceAssistAiConfig;
+    prompt: VoiceAssistPrompt;
+  }) => unknown;
+  transformResponse?: (data: unknown) => string;
+};
+
+export type VoiceAssistSpeechConfig = {
+  locale?: string;
+  interimResults?: boolean;
+  insertionMode?: 'append' | 'replace-selection' | 'replace-all';
+};
+
+export type VoiceAssistAiRequest = (ctx: {
+  text: string;
+  instruction: string;
+  config: VoiceAssistAiConfig;
+  signal?: AbortSignal;
+  prompt: VoiceAssistPrompt;
+}) => Promise<string>;
+
+export interface VoiceAssistOptions {
+  root?: Document | HTMLElement | ShadowRoot;
+  autoAttach?: boolean;
+  prompts?: VoiceAssistPrompt[];
+  aiConfig?: Partial<VoiceAssistAiConfig>;
+  aiInsertionMode?: 'append' | 'replace-selection' | 'replace-all';
+  speechConfig?: VoiceAssistSpeechConfig;
+  aiRequest?: VoiceAssistAiRequest;
+}
+
+export declare class VoiceAssistPlugin {
+  constructor(options?: VoiceAssistOptions);
+
+  prompts: VoiceAssistPrompt[];
+  activeElement: HTMLElement | null;
+  speechConfig: VoiceAssistSpeechConfig;
+
+  attach(): void;
+  detach(): void;
+  destroy(): void;
+
+  startSpeechCapture(): void;
+  stopSpeechCapture(): void;
+
+  runAiAction(prompt: VoiceAssistPrompt): Promise<void>;
+
+  getAIConfig(): VoiceAssistAiConfig;
+  setAIConfig(config: Partial<VoiceAssistAiConfig>): void;
+
+  getSpeechConfig(): VoiceAssistSpeechConfig;
+  setSpeechConfig(config: Partial<VoiceAssistSpeechConfig>): void;
+
+  getAiInsertionMode(): 'append' | 'replace-selection' | 'replace-all';
+  setAiInsertionMode(mode: 'append' | 'replace-selection' | 'replace-all'): void;
+
+  setPrompts(prompts: VoiceAssistPrompt[]): void;
+}
+
+export declare const DEFAULT_PROMPTS: VoiceAssistPrompt[];
+export declare const DEFAULT_AI_CONFIG: VoiceAssistAiConfig;
+export declare const defaultAiRequest: VoiceAssistAiRequest;
+
+export default VoiceAssistPlugin;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,1064 @@
+const DEFAULT_PROMPTS = [
+  {
+    id: 'improve-clarity',
+    label: 'Improve clarity',
+    instruction: 'Rewrite the following text to make it clearer while keeping the same meaning.'
+  },
+  {
+    id: 'fix-grammar',
+    label: 'Fix grammar',
+    instruction: 'Fix grammar and spelling issues in the following text without changing the original meaning.'
+  },
+  {
+    id: 'summarize',
+    label: 'Summarize',
+    instruction: 'Summarize the following text in a concise paragraph.'
+  },
+  {
+    id: 'expand',
+    label: 'Expand',
+    instruction: 'Expand on the following text by adding more detail and context.'
+  }
+];
+
+const DEFAULT_AI_CONFIG = {
+  provider: 'openai-compatible',
+  endpoint: '',
+  apiKey: '',
+  model: 'gpt-3.5-turbo',
+  headers: {},
+  systemPrompt: 'You are a helpful writing assistant.'
+};
+
+const STYLE_ID = 'voice-assist-plugin-style';
+const BASE_STYLES = `
+.voice-assist-plugin-container {
+  position: absolute;
+  z-index: 99999;
+  width: 320px;
+  max-width: 90vw;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.15);
+  background: #ffffff;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  color: #0f172a;
+  overflow: hidden;
+  transform-origin: top left;
+  animation: va-fade-in 120ms ease-out;
+}
+
+.voice-assist-plugin-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #fff;
+}
+
+.voice-assist-plugin-header h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.voice-assist-plugin-header-buttons {
+  display: flex;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.voice-assist-plugin-body {
+  padding: 0.75rem 1rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.voice-assist-plugin-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.voice-assist-plugin-section h3 {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #475569;
+}
+
+.voice-assist-plugin-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.voice-assist-plugin-button {
+  appearance: none;
+  border: none;
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  background: #e2e8f0;
+  color: #0f172a;
+  transition: background 120ms ease, transform 120ms ease;
+}
+
+.voice-assist-plugin-button.primary {
+  background: #2563eb;
+  color: #fff;
+}
+
+.voice-assist-plugin-button:hover {
+  background: #cbd5f5;
+  transform: translateY(-1px);
+}
+
+.voice-assist-plugin-button:disabled,
+.voice-assist-plugin-button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.voice-assist-plugin-status {
+  min-height: 1.25rem;
+  font-size: 0.75rem;
+  color: #334155;
+}
+
+.voice-assist-plugin-status.error {
+  color: #dc2626;
+}
+
+.voice-assist-plugin-status.success {
+  color: #16a34a;
+}
+
+.voice-assist-plugin-config {
+  border-top: 1px solid #e2e8f0;
+  padding-top: 0.75rem;
+  display: none;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.voice-assist-plugin-config.open {
+  display: flex;
+}
+
+.voice-assist-plugin-config label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.75rem;
+  color: #475569;
+  gap: 0.35rem;
+}
+
+.voice-assist-plugin-config input,
+.voice-assist-plugin-config textarea {
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.8rem;
+  font-family: inherit;
+}
+
+.voice-assist-plugin-config textarea {
+  resize: vertical;
+  min-height: 60px;
+}
+
+.voice-assist-plugin-config-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+@keyframes va-fade-in {
+  from { opacity: 0; transform: scale(0.97); }
+  to { opacity: 1; transform: scale(1); }
+}
+`;
+
+const VALID_INSERTION_MODES = ['append', 'replace-selection', 'replace-all'];
+
+function normalizeInsertionMode(mode, fallback = 'append') {
+  if (typeof mode === 'string' && VALID_INSERTION_MODES.includes(mode)) {
+    return mode;
+  }
+  return fallback;
+}
+
+function mergeSpeechConfig(baseConfig = {}, patch = {}) {
+  const merged = { ...baseConfig, ...(patch || {}) };
+  merged.insertionMode = normalizeInsertionMode(
+    merged.insertionMode,
+    baseConfig.insertionMode ?? 'append'
+  );
+  if (!merged.insertionMode) {
+    merged.insertionMode = 'append';
+  }
+  return merged;
+}
+
+function ensureStyles() {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = BASE_STYLES;
+  document.head.appendChild(style);
+}
+
+function isTextLikeElement(element) {
+  if (!element) return false;
+  const tagName = element.tagName ? element.tagName.toLowerCase() : '';
+  if (tagName === 'textarea') return true;
+  if (tagName === 'input') {
+    const type = element.type ? element.type.toLowerCase() : 'text';
+    return ['text', 'search', 'email', 'url', 'tel', 'number', 'password'].includes(type);
+  }
+  if (element.isContentEditable) return true;
+  return false;
+}
+
+function getActiveSelection(element) {
+  if (!element) {
+    return { text: '', range: null, start: null, end: null };
+  }
+
+  if (element instanceof HTMLTextAreaElement || element instanceof HTMLInputElement) {
+    const start = element.selectionStart ?? 0;
+    const end = element.selectionEnd ?? start;
+    return {
+      text: element.value.slice(start, end),
+      range: null,
+      start,
+      end
+    };
+  }
+
+  if (element.isContentEditable) {
+    const selection = window.getSelection();
+    if (selection && selection.rangeCount > 0) {
+      const range = selection.getRangeAt(0);
+      if (element.contains(range.commonAncestorContainer)) {
+        return { text: selection.toString(), range, start: null, end: null };
+      }
+    }
+  }
+
+  return { text: '', range: null, start: null, end: null };
+}
+
+function replaceSelection(element, replacement) {
+  if (!element) return;
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    const start = element.selectionStart ?? element.value.length;
+    const end = element.selectionEnd ?? element.value.length;
+    const before = element.value.slice(0, start);
+    const after = element.value.slice(end);
+    const nextValue = `${before}${replacement}${after}`;
+    const cursorPosition = start + replacement.length;
+    element.value = nextValue;
+    element.setSelectionRange(cursorPosition, cursorPosition);
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+    return;
+  }
+
+  if (element.isContentEditable) {
+    element.focus({ preventScroll: true });
+    const selection = window.getSelection();
+    if (selection && selection.rangeCount > 0) {
+      const range = selection.getRangeAt(0);
+      if (!element.contains(range.commonAncestorContainer)) {
+        selection.removeAllRanges();
+        const newRange = document.createRange();
+        newRange.selectNodeContents(element);
+        newRange.collapse(false);
+        selection.addRange(newRange);
+      }
+      range.deleteContents();
+      range.insertNode(document.createTextNode(replacement));
+      range.collapse(false);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    } else {
+      element.append(document.createTextNode(replacement));
+    }
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+}
+
+function replaceAllText(element, text) {
+  if (!element) return;
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    element.value = text;
+    const caret = element.value.length;
+    element.setSelectionRange(caret, caret);
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+    return;
+  }
+
+  if (element.isContentEditable) {
+    element.focus({ preventScroll: true });
+    element.textContent = text;
+    const selection = window.getSelection();
+    if (selection) {
+      selection.selectAllChildren(element);
+      selection.collapseToEnd();
+    }
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+}
+
+function appendText(element, text) {
+  if (!element) return;
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    const nextValue = `${element.value}${text}`;
+    element.value = nextValue;
+    element.setSelectionRange(nextValue.length, nextValue.length);
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+    return;
+  }
+  if (element.isContentEditable) {
+    element.focus({ preventScroll: true });
+    element.append(document.createTextNode(text));
+    const selection = window.getSelection();
+    if (selection) {
+      selection.selectAllChildren(element);
+      selection.collapseToEnd();
+    }
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+  }
+}
+
+function buildPromptedInput({ instruction, text, systemPrompt }) {
+  const userContent = `${instruction}\n\n${text}`;
+  return {
+    model: 'gpt-3.5-turbo',
+    systemPrompt,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userContent }
+    ]
+  };
+}
+
+async function defaultAiRequest({ text, instruction, config, signal, prompt }) {
+  if (!config || !config.endpoint) {
+    throw new Error('AI endpoint is not configured. Provide an endpoint in the plugin configuration.');
+  }
+
+  if (typeof fetch !== 'function') {
+    throw new Error('Fetch API is not available in this environment. Provide a custom aiRequest implementation.');
+  }
+
+  const headers = Object.assign(
+    {
+      'Content-Type': 'application/json'
+    },
+    config.headers || {}
+  );
+
+  if (config.apiKey && !headers.Authorization) {
+    headers.Authorization = `Bearer ${config.apiKey}`;
+  }
+
+  const payloadBuilder = typeof config.buildPayload === 'function'
+    ? config.buildPayload
+    : ({ instruction: inst, text: content, config: cfg }) => {
+      const prompt = buildPromptedInput({
+        instruction: inst,
+        text: content,
+        systemPrompt: cfg.systemPrompt || DEFAULT_AI_CONFIG.systemPrompt
+      });
+      return {
+        model: cfg.model || DEFAULT_AI_CONFIG.model,
+        messages: prompt.messages
+      };
+    };
+
+  const payload = payloadBuilder({
+    instruction,
+    text,
+    config,
+    prompt: prompt || {
+      id: 'custom',
+      label: 'Custom request',
+      instruction
+    }
+  });
+
+  const response = await fetch(config.endpoint, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+    signal
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`AI request failed (${response.status}): ${errorText}`);
+  }
+
+  const data = await response.json();
+
+  if (typeof config.transformResponse === 'function') {
+    return config.transformResponse(data);
+  }
+
+  const content = data?.choices?.[0]?.message?.content
+    || data?.choices?.[0]?.text
+    || data?.output
+    || data?.result;
+
+  if (!content) {
+    throw new Error('Unexpected AI response format. Provide a transformResponse function to map it.');
+  }
+
+  return String(content).trim();
+}
+
+class AssistUI {
+  constructor(plugin) {
+    this.plugin = plugin;
+    this.container = null;
+    this.statusNode = null;
+    this.promptButtonsWrapper = null;
+    this.configSection = null;
+    this.configForm = null;
+    this.speechButton = null;
+    this.speechStopButton = null;
+    this.resizeObserver = null;
+    this.observedElement = null;
+    this.isVisible = false;
+    this.speechSupported = true;
+    ensureStyles();
+    this.createUI();
+  }
+
+  createUI() {
+    if (typeof document === 'undefined') return;
+    this.container = document.createElement('div');
+    this.container.className = 'voice-assist-plugin-container';
+    this.container.tabIndex = -1;
+
+    const header = document.createElement('div');
+    header.className = 'voice-assist-plugin-header';
+    const title = document.createElement('h2');
+    title.textContent = 'Voice & AI Assistant';
+    header.appendChild(title);
+
+    const headerButtons = document.createElement('div');
+    headerButtons.className = 'voice-assist-plugin-header-buttons';
+
+    const configToggle = document.createElement('button');
+    configToggle.type = 'button';
+    configToggle.className = 'voice-assist-plugin-button';
+    configToggle.title = 'Configure AI model';
+    configToggle.innerHTML = '⚙️ Config';
+    configToggle.addEventListener('click', () => {
+      this.toggleConfig();
+    });
+
+    headerButtons.appendChild(configToggle);
+
+    header.appendChild(headerButtons);
+
+    const body = document.createElement('div');
+    body.className = 'voice-assist-plugin-body';
+
+    const speechSection = document.createElement('div');
+    speechSection.className = 'voice-assist-plugin-section';
+    const speechTitle = document.createElement('h3');
+    speechTitle.textContent = 'Speech to text';
+    speechSection.appendChild(speechTitle);
+    const speechActions = document.createElement('div');
+    speechActions.className = 'voice-assist-plugin-actions';
+
+    this.speechButton = document.createElement('button');
+    this.speechButton.type = 'button';
+    this.speechButton.className = 'voice-assist-plugin-button primary';
+    this.speechButton.textContent = '🎤 Start speaking';
+
+    this.speechStopButton = document.createElement('button');
+    this.speechStopButton.type = 'button';
+    this.speechStopButton.className = 'voice-assist-plugin-button';
+    this.speechStopButton.textContent = '⏹ Stop';
+    this.speechStopButton.disabled = true;
+
+    this.speechButton.addEventListener('click', () => this.plugin.startSpeechCapture());
+    this.speechStopButton.addEventListener('click', () => this.plugin.stopSpeechCapture());
+
+    speechActions.appendChild(this.speechButton);
+    speechActions.appendChild(this.speechStopButton);
+    speechSection.appendChild(speechActions);
+
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    this.speechSupported = Boolean(SpeechRecognition);
+    if (!this.speechSupported) {
+      this.speechButton.disabled = true;
+      this.speechButton.textContent = '🎤 Not supported';
+      this.speechButton.title = 'Speech recognition is unavailable in this browser.';
+      this.speechStopButton.disabled = true;
+    }
+
+    const aiSection = document.createElement('div');
+    aiSection.className = 'voice-assist-plugin-section';
+    const aiTitle = document.createElement('h3');
+    aiTitle.textContent = 'AI reformatting';
+    aiSection.appendChild(aiTitle);
+
+    this.promptButtonsWrapper = document.createElement('div');
+    this.promptButtonsWrapper.className = 'voice-assist-plugin-actions';
+    aiSection.appendChild(this.promptButtonsWrapper);
+
+    const status = document.createElement('div');
+    status.className = 'voice-assist-plugin-status';
+    this.statusNode = status;
+
+    this.configSection = document.createElement('div');
+    this.configSection.className = 'voice-assist-plugin-config';
+    this.configForm = document.createElement('form');
+
+    const endpointField = this.createLabeledInput('Endpoint URL', 'text', 'endpoint');
+    const apiKeyField = this.createLabeledInput('API key (optional)', 'text', 'apiKey');
+    const modelField = this.createLabeledInput('Model name', 'text', 'model');
+    const systemPromptField = this.createLabeledTextarea('System prompt (optional)', 'systemPrompt');
+
+    this.configForm.appendChild(endpointField);
+    this.configForm.appendChild(apiKeyField);
+    this.configForm.appendChild(modelField);
+    this.configForm.appendChild(systemPromptField);
+
+    const configActions = document.createElement('div');
+    configActions.className = 'voice-assist-plugin-config-actions';
+    const cancelConfig = document.createElement('button');
+    cancelConfig.type = 'button';
+    cancelConfig.className = 'voice-assist-plugin-button';
+    cancelConfig.textContent = 'Cancel';
+    cancelConfig.addEventListener('click', () => this.toggleConfig(false));
+
+    const saveConfig = document.createElement('button');
+    saveConfig.type = 'submit';
+    saveConfig.className = 'voice-assist-plugin-button primary';
+    saveConfig.textContent = 'Save';
+
+    configActions.appendChild(cancelConfig);
+    configActions.appendChild(saveConfig);
+    this.configForm.appendChild(configActions);
+
+    this.configForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const formData = new FormData(this.configForm);
+      const nextConfig = {
+        ...this.plugin.getAIConfig(),
+        endpoint: formData.get('endpoint') || '',
+        apiKey: formData.get('apiKey') || '',
+        model: formData.get('model') || '',
+        systemPrompt: formData.get('systemPrompt') || ''
+      };
+      this.plugin.setAIConfig(nextConfig);
+      this.toggleConfig(false);
+      this.setStatus('AI configuration updated.', 'success');
+    });
+
+    this.configSection.appendChild(this.configForm);
+
+    body.appendChild(speechSection);
+    body.appendChild(aiSection);
+    body.appendChild(status);
+    body.appendChild(this.configSection);
+
+    this.container.appendChild(header);
+    this.container.appendChild(body);
+
+    if (document.body) {
+      document.body.appendChild(this.container);
+    } else {
+      document.addEventListener('DOMContentLoaded', () => {
+        document.body.appendChild(this.container);
+      }, { once: true });
+    }
+
+    this.container.addEventListener('mousedown', (event) => {
+      event.preventDefault();
+    });
+
+    this.renderPromptButtons(this.plugin.prompts);
+    this.syncConfigForm(this.plugin.getAIConfig());
+  }
+
+  createLabeledInput(label, type, name) {
+    const wrapper = document.createElement('label');
+    wrapper.textContent = label;
+    const input = document.createElement('input');
+    input.type = type;
+    input.name = name;
+    input.autocomplete = 'off';
+    wrapper.appendChild(input);
+    return wrapper;
+  }
+
+  createLabeledTextarea(label, name) {
+    const wrapper = document.createElement('label');
+    wrapper.textContent = label;
+    const input = document.createElement('textarea');
+    input.name = name;
+    wrapper.appendChild(input);
+    return wrapper;
+  }
+
+  toggleConfig(force) {
+    if (!this.configSection) return;
+    const shouldOpen = typeof force === 'boolean' ? force : !this.configSection.classList.contains('open');
+    if (shouldOpen) {
+      this.syncConfigForm(this.plugin.getAIConfig());
+      this.configSection.classList.add('open');
+    } else {
+      this.configSection.classList.remove('open');
+    }
+  }
+
+  syncConfigForm(config) {
+    if (!this.configForm) return;
+    const endpoint = this.configForm.querySelector('input[name="endpoint"]');
+    const apiKey = this.configForm.querySelector('input[name="apiKey"]');
+    const model = this.configForm.querySelector('input[name="model"]');
+    const systemPrompt = this.configForm.querySelector('textarea[name="systemPrompt"]');
+
+    if (endpoint) endpoint.value = config.endpoint || '';
+    if (apiKey) apiKey.value = config.apiKey || '';
+    if (model) model.value = config.model || '';
+    if (systemPrompt) systemPrompt.value = config.systemPrompt || '';
+  }
+
+  renderPromptButtons(prompts = []) {
+    if (!this.promptButtonsWrapper) return;
+    this.promptButtonsWrapper.innerHTML = '';
+    if (!prompts.length) {
+      const note = document.createElement('p');
+      note.textContent = 'No AI actions configured.';
+      note.style.fontSize = '0.8rem';
+      note.style.color = '#475569';
+      this.promptButtonsWrapper.appendChild(note);
+      return;
+    }
+
+    prompts.forEach((prompt) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'voice-assist-plugin-button';
+      button.textContent = prompt.label;
+      button.dataset.promptId = prompt.id;
+      button.addEventListener('click', () => {
+        this.plugin.runAiAction(prompt);
+      });
+      this.promptButtonsWrapper.appendChild(button);
+    });
+  }
+
+  show(targetElement) {
+    if (!this.container || !targetElement) return;
+    this.isVisible = true;
+    this.container.style.display = 'block';
+    this.positionRelativeTo(targetElement);
+    if (typeof ResizeObserver === 'function' && !this.resizeObserver) {
+      this.resizeObserver = new ResizeObserver(() => {
+        if (this.plugin.activeElement) {
+          this.positionRelativeTo(this.plugin.activeElement);
+        }
+      });
+    }
+    if (this.resizeObserver && this.observedElement && this.observedElement !== targetElement) {
+      try {
+        this.resizeObserver.unobserve(this.observedElement);
+      } catch (error) {
+        // ignore detach errors
+      }
+    }
+    if (this.resizeObserver) {
+      this.resizeObserver.observe(targetElement);
+      this.observedElement = targetElement;
+    } else {
+      this.observedElement = null;
+    }
+  }
+
+  hide() {
+    if (!this.container) return;
+    this.isVisible = false;
+    this.container.style.display = 'none';
+    if (this.resizeObserver && this.observedElement) {
+      try {
+        this.resizeObserver.unobserve(this.observedElement);
+      } catch (error) {
+        // ignore when element already detached
+      }
+    }
+    this.observedElement = null;
+  }
+
+  positionRelativeTo(targetElement) {
+    if (!this.container || !targetElement) return;
+    const rect = targetElement.getBoundingClientRect();
+    const top = rect.bottom + window.scrollY + 8;
+    let left = rect.left + window.scrollX;
+    const containerWidth = this.container.offsetWidth;
+    const viewportWidth = window.innerWidth;
+    if (left + containerWidth > viewportWidth - 12) {
+      left = viewportWidth - containerWidth - 12;
+    }
+    if (left < 12) left = 12;
+    this.container.style.top = `${top}px`;
+    this.container.style.left = `${left}px`;
+  }
+
+  setStatus(message, tone = 'neutral') {
+    if (!this.statusNode) return;
+    this.statusNode.textContent = message || '';
+    this.statusNode.classList.remove('error', 'success');
+    if (tone === 'error') {
+      this.statusNode.classList.add('error');
+    } else if (tone === 'success') {
+      this.statusNode.classList.add('success');
+    }
+  }
+
+  setSpeechCapturing(active) {
+    if (!this.speechButton || !this.speechStopButton) return;
+    if (!this.speechSupported) {
+      this.speechButton.disabled = true;
+      this.speechStopButton.disabled = true;
+      return;
+    }
+    this.speechButton.disabled = active;
+    this.speechStopButton.disabled = !active;
+    if (active) {
+      this.speechButton.textContent = '🎤 Listening…';
+    } else {
+      this.speechButton.textContent = '🎤 Start speaking';
+    }
+  }
+
+  destroy() {
+    if (this.container && this.container.parentNode) {
+      this.container.parentNode.removeChild(this.container);
+    }
+    this.container = null;
+    this.statusNode = null;
+    this.promptButtonsWrapper = null;
+    this.configSection = null;
+    this.configForm = null;
+    if (this.resizeObserver && this.observedElement) {
+      try {
+        this.resizeObserver.unobserve(this.observedElement);
+      } catch (error) {
+        // ignore
+      }
+    }
+    this.resizeObserver = null;
+    this.observedElement = null;
+  }
+}
+
+export class VoiceAssistPlugin {
+  constructor(options = {}) {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      throw new Error('VoiceAssistPlugin must be used in a browser-like environment.');
+    }
+    this.options = options;
+    this.prompts = Array.isArray(options.prompts) ? options.prompts : DEFAULT_PROMPTS.slice();
+    this.aiConfig = { ...DEFAULT_AI_CONFIG, ...(options.aiConfig || {}) };
+    const defaultSpeechConfig = {
+      locale: 'en-US',
+      interimResults: false,
+      insertionMode: 'append'
+    };
+    this.speechConfig = mergeSpeechConfig(defaultSpeechConfig, options.speechConfig);
+    this.aiInsertionMode = options.aiInsertionMode || 'replace-selection';
+    this.activeElement = null;
+    this.ui = null;
+    this.root = options.root || document;
+    this.autoAttach = options.autoAttach !== false;
+    this.isListening = false;
+    this.recognition = null;
+    this.pendingAiAbortController = null;
+    this.isAttached = false;
+
+    this.onFocusIn = this.onFocusIn.bind(this);
+    this.onFocusOut = this.onFocusOut.bind(this);
+    this.onWindowChange = this.onWindowChange.bind(this);
+    this.onDocumentClick = this.onDocumentClick.bind(this);
+
+    if (this.autoAttach) {
+      this.attach();
+    }
+  }
+
+  attach() {
+    if (this.isAttached) return;
+    this.root.addEventListener('focusin', this.onFocusIn);
+    this.root.addEventListener('focusout', this.onFocusOut);
+    window.addEventListener('resize', this.onWindowChange);
+    document.addEventListener('scroll', this.onWindowChange, true);
+    document.addEventListener('click', this.onDocumentClick);
+    this.isAttached = true;
+  }
+
+  detach() {
+    if (!this.isAttached) return;
+    this.root.removeEventListener('focusin', this.onFocusIn);
+    this.root.removeEventListener('focusout', this.onFocusOut);
+    window.removeEventListener('resize', this.onWindowChange);
+    document.removeEventListener('scroll', this.onWindowChange, true);
+    document.removeEventListener('click', this.onDocumentClick);
+    this.isAttached = false;
+  }
+
+  destroy() {
+    this.detach();
+    this.stopSpeechCapture();
+    if (this.pendingAiAbortController) {
+      this.pendingAiAbortController.abort();
+      this.pendingAiAbortController = null;
+    }
+    if (this.ui) {
+      this.ui.destroy();
+      this.ui = null;
+    }
+    this.activeElement = null;
+  }
+
+  ensureUI() {
+    if (!this.ui) {
+      this.ui = new AssistUI(this);
+    }
+    return this.ui;
+  }
+
+  onFocusIn(event) {
+    const target = event.target;
+    if (!isTextLikeElement(target)) {
+      return;
+    }
+    this.activeElement = target;
+    this.ensureUI().show(target);
+    this.ensureUI().setStatus('');
+  }
+
+  onFocusOut(event) {
+    const nextFocus = event.relatedTarget;
+    if (nextFocus && this.ui && this.ui.container && this.ui.container.contains(nextFocus)) {
+      return;
+    }
+    setTimeout(() => {
+      const active = document.activeElement;
+      if (this.ui && (!active || !this.ui.container.contains(active)) && active !== this.activeElement) {
+        this.ui.hide();
+      }
+    }, 150);
+  }
+
+  onWindowChange() {
+    if (this.ui && this.ui.isVisible && this.activeElement) {
+      this.ui.positionRelativeTo(this.activeElement);
+    }
+  }
+
+  onDocumentClick(event) {
+    if (!this.ui || !this.ui.container) return;
+    if (!this.ui.isVisible) return;
+    if (this.ui.container.contains(event.target)) return;
+    if (this.activeElement && this.activeElement.contains && this.activeElement.contains(event.target)) return;
+    this.ui.hide();
+  }
+
+  startSpeechCapture() {
+    if (!this.activeElement) {
+      this.ensureUI().setStatus('Focus a text input before starting speech capture.', 'error');
+      return;
+    }
+    if (this.isListening) return;
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    if (!SpeechRecognition) {
+      this.ensureUI().setStatus('Speech recognition is not supported in this browser.', 'error');
+      return;
+    }
+
+    this.recognition = new SpeechRecognition();
+    this.recognition.lang = this.speechConfig.locale || 'en-US';
+    this.recognition.interimResults = Boolean(this.speechConfig.interimResults);
+    this.recognition.continuous = false;
+
+    this.recognition.onstart = () => {
+      this.isListening = true;
+      this.ensureUI().setSpeechCapturing(true);
+      this.ensureUI().setStatus('Listening…');
+    };
+
+    this.recognition.onresult = (event) => {
+      const transcript = Array.from(event.results)
+        .map((result) => result[0]?.transcript || '')
+        .join(' ')
+        .trim();
+      if (!transcript) {
+        this.ensureUI().setStatus('No speech detected. Try again.');
+        return;
+      }
+      const mode = normalizeInsertionMode(this.speechConfig.insertionMode, 'append');
+      if (mode === 'replace-selection') {
+        replaceSelection(this.activeElement, transcript);
+      } else if (mode === 'replace-all') {
+        replaceAllText(this.activeElement, transcript);
+      } else {
+        appendText(this.activeElement, ` ${transcript}`.trimStart());
+      }
+      this.ensureUI().setStatus('Transcription inserted.', 'success');
+    };
+
+    this.recognition.onerror = (event) => {
+      this.ensureUI().setStatus(`Speech error: ${event.error || 'unknown error'}`, 'error');
+    };
+
+    this.recognition.onend = () => {
+      this.isListening = false;
+      this.ensureUI().setSpeechCapturing(false);
+    };
+
+    try {
+      this.recognition.start();
+    } catch (error) {
+      this.isListening = false;
+      this.ensureUI().setSpeechCapturing(false);
+      this.ensureUI().setStatus(`Unable to start speech recognition: ${error.message}`, 'error');
+    }
+  }
+
+  stopSpeechCapture() {
+    if (this.recognition && this.isListening) {
+      try {
+        this.recognition.stop();
+      } catch (error) {
+        this.ensureUI().setStatus(`Unable to stop speech recognition: ${error.message}`, 'error');
+      }
+    }
+  }
+
+  getAIConfig() {
+    return { ...this.aiConfig };
+  }
+
+  setAIConfig(nextConfig = {}) {
+    this.aiConfig = { ...this.aiConfig, ...nextConfig };
+    if (this.ui) {
+      this.ui.syncConfigForm(this.aiConfig);
+    }
+  }
+
+  getSpeechConfig() {
+    return { ...this.speechConfig };
+  }
+
+  setSpeechConfig(nextConfig = {}) {
+    this.speechConfig = mergeSpeechConfig(this.speechConfig, nextConfig);
+  }
+
+  setAiInsertionMode(mode = 'replace-selection') {
+    if (!VALID_INSERTION_MODES.includes(mode)) {
+      throw new Error('aiInsertionMode must be one of: append, replace-selection, replace-all');
+    }
+    this.aiInsertionMode = mode;
+  }
+
+  getAiInsertionMode() {
+    return this.aiInsertionMode;
+  }
+
+  setPrompts(prompts = []) {
+    this.prompts = prompts.slice();
+    if (this.ui) {
+      this.ui.renderPromptButtons(this.prompts);
+    }
+  }
+
+  async runAiAction(prompt) {
+    if (!this.activeElement) {
+      this.ensureUI().setStatus('Select a text input to use AI actions.', 'error');
+      return;
+    }
+
+    if (this.pendingAiAbortController) {
+      this.pendingAiAbortController.abort();
+      this.pendingAiAbortController = null;
+    }
+
+    const selection = getActiveSelection(this.activeElement);
+    const baseValue = typeof this.activeElement.value === 'string'
+      ? this.activeElement.value
+      : (this.activeElement.innerText ?? this.activeElement.textContent ?? '');
+    const textTarget = selection.text || baseValue;
+    const normalizedText = (textTarget || '').trim();
+
+    if (!normalizedText) {
+      this.ensureUI().setStatus('There is no text to send to the AI yet.', 'error');
+      return;
+    }
+
+    this.ensureUI().setStatus(`Running “${prompt.label}”…`);
+
+    const controller = new AbortController();
+    this.pendingAiAbortController = controller;
+
+    try {
+      const requestHandler = typeof this.options.aiRequest === 'function' ? this.options.aiRequest : defaultAiRequest;
+      const aiResponse = await requestHandler({
+        text: normalizedText,
+        instruction: prompt.instruction,
+        config: this.aiConfig,
+        signal: controller.signal,
+        prompt
+      });
+
+      if (selection.text) {
+        replaceSelection(this.activeElement, aiResponse);
+      } else if (this.aiInsertionMode === 'replace-all') {
+        replaceAllText(this.activeElement, aiResponse);
+      } else {
+        appendText(this.activeElement, ` ${aiResponse}`.trimStart());
+      }
+
+      this.ensureUI().setStatus(`${prompt.label} applied.`, 'success');
+    } catch (error) {
+      if (controller.signal.aborted) {
+        this.ensureUI().setStatus('AI request cancelled.', 'error');
+      } else {
+        this.ensureUI().setStatus(error.message, 'error');
+      }
+    } finally {
+      if (this.pendingAiAbortController === controller) {
+        this.pendingAiAbortController = null;
+      }
+    }
+  }
+}
+
+export default VoiceAssistPlugin;
+export { DEFAULT_PROMPTS, DEFAULT_AI_CONFIG, defaultAiRequest };

--- a/tests/defaultAiRequest.test.js
+++ b/tests/defaultAiRequest.test.js
@@ -1,0 +1,77 @@
+import test, { afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { defaultAiRequest, DEFAULT_AI_CONFIG } from '../src/index.js';
+
+const originalFetch = global.fetch;
+
+afterEach(() => {
+  if (originalFetch === undefined) {
+    delete global.fetch;
+  } else {
+    global.fetch = originalFetch;
+  }
+});
+
+test('defaultAiRequest builds an OpenAI-compatible payload with defaults', async () => {
+  let received;
+  global.fetch = async (url, options) => {
+    received = { url, options };
+    return {
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: 'Updated text' } }] })
+    };
+  };
+
+  const config = {
+    ...DEFAULT_AI_CONFIG,
+    endpoint: 'https://example.com/v1/chat/completions',
+    apiKey: 'secret-key',
+    model: 'gpt-custom'
+  };
+
+  const result = await defaultAiRequest({
+    text: 'Original input',
+    instruction: 'Fix grammar',
+    config,
+    prompt: { id: 'fix', label: 'Fix grammar', instruction: 'Fix grammar' }
+  });
+
+  assert.equal(result, 'Updated text');
+  assert.equal(received.url, 'https://example.com/v1/chat/completions');
+  assert.equal(received.options.method, 'POST');
+  const body = JSON.parse(received.options.body);
+  assert.equal(body.model, 'gpt-custom');
+  assert.equal(body.messages[1].content, 'Fix grammar\n\nOriginal input');
+  assert.equal(received.options.headers.Authorization, 'Bearer secret-key');
+});
+
+test('defaultAiRequest forwards prompt metadata to custom payload builders', async () => {
+  let seenContext;
+  global.fetch = async () => ({
+    ok: true,
+    json: async () => ({ output: 'rewritten text' })
+  });
+
+  const config = {
+    endpoint: 'https://example.com',
+    buildPayload: (ctx) => {
+      seenContext = ctx;
+      return { body: ctx.text, promptUsed: ctx.prompt.id };
+    },
+    transformResponse: (data) => data.output
+  };
+
+  const prompt = { id: 'expand', label: 'Expand', instruction: 'Expand the text' };
+
+  const result = await defaultAiRequest({
+    text: 'Hello world',
+    instruction: 'Expand the text',
+    config,
+    prompt
+  });
+
+  assert.equal(result, 'rewritten text');
+  assert.deepEqual(seenContext.prompt, prompt);
+  assert.equal(seenContext.instruction, 'Expand the text');
+});


### PR DESCRIPTION
## Summary
- add a Vite-powered React example that mounts the assistant and styles a demo editor
- add an Angular CLI standalone demo wiring the plugin through lifecycle hooks
- document how to install and run the new examples alongside the existing vanilla sample

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9759eba28832b8d089bf3fc03a6ae